### PR TITLE
Adds api audience to apiserver service account bounded tokens

### DIFF
--- a/puppet/modules/kubernetes/manifests/apiserver.pp
+++ b/puppet/modules/kubernetes/manifests/apiserver.pp
@@ -30,6 +30,7 @@ class kubernetes::apiserver(
   $cert_file = undef,
   $key_file = undef,
   String $service_account_issuer ='kubernetes.default.svc',
+  Optional[Array[String]] $service_account_api_audiences = undef,
   Optional[String] $oidc_client_id = undef,
   Optional[String] $oidc_groups_claim = undef,
   Optional[String] $oidc_groups_prefix = undef,
@@ -72,6 +73,12 @@ class kubernetes::apiserver(
     $_audit_enabled = $post_1_8
   } else {
     $_audit_enabled = $audit_enabled
+  }
+
+  if $service_account_api_audiences == undef {
+    $_service_account_api_audiences = [$service_account_issuer]
+  } else {
+    $_service_account_api_audiences = $service_account_api_audiences
   }
 
   # Admission controllers cf. https://kubernetes.io/docs/admin/admission-controllers/

--- a/puppet/modules/kubernetes/manifests/apiserver.pp
+++ b/puppet/modules/kubernetes/manifests/apiserver.pp
@@ -58,6 +58,7 @@ class kubernetes::apiserver(
   $tls_cipher_suites = $::kubernetes::tls_cipher_suites
 
   $post_1_14 = versioncmp($::kubernetes::version, '1.14.0') >= 0
+  $post_1_13 = versioncmp($::kubernetes::version, '1.13.0') >= 0
   $post_1_12 = versioncmp($::kubernetes::version, '1.12.0') >= 0
   $post_1_11 = versioncmp($::kubernetes::version, '1.11.0') >= 0
   $post_1_10 = versioncmp($::kubernetes::version, '1.10.0') >= 0

--- a/puppet/modules/kubernetes/spec/classes/apiserver_spec.rb
+++ b/puppet/modules/kubernetes/spec/classes/apiserver_spec.rb
@@ -333,6 +333,20 @@ describe 'kubernetes::apiserver' do
       it do
         should contain_file(service_file).with_content(/#{Regexp.escape('--service-account-signing-key-file=/etc/kubernetes/sa.key')}/)
         should contain_file(service_file).with_content(/#{Regexp.escape('--service-account-issuer=kubernetes.default.svc')}/)
+        should contain_file(service_file).with_content(/#{Regexp.escape('--service-account-api-audiences=kubernetes.default.svc')}/)
+      end
+    end
+    context 'with kubernetes 1.12+ with custom audiences' do
+      let(:pre_condition) {[
+        """
+            class{'kubernetes': version => '1.12.0', service_account_key_file => '/etc/kubernetes/sa.key'}
+            class{'kubernetes::apiserver': service_account_api_audiences => ['kubernetes.default.svc', 'my.custom.aud.svc']}
+        """
+      ]}
+      it do
+        should contain_file(service_file).with_content(/#{Regexp.escape('--service-account-signing-key-file=/etc/kubernetes/sa.key')}/)
+        should contain_file(service_file).with_content(/#{Regexp.escape('--service-account-issuer=kubernetes.default.svc')}/)
+        should contain_file(service_file).with_content(/#{Regexp.escape('--service-account-api-audiences=kubernetes.default.svc,my.custom.aud.svc')}/)
       end
     end
     context 'with kubernetes before 1.12' do
@@ -344,6 +358,7 @@ describe 'kubernetes::apiserver' do
       it do
         should_not contain_file(service_file).with_content(/#{Regexp.escape('--service-account-signing-key-file=/etc/kubernetes/sa.key')}/)
         should_not contain_file(service_file).with_content(/#{Regexp.escape('--service-account-issuer=')}/)
+        should_not contain_file(service_file).with_content(/#{Regexp.escape('--service-account-api-audiences=')}/)
       end
     end
   end

--- a/puppet/modules/kubernetes/spec/classes/apiserver_spec.rb
+++ b/puppet/modules/kubernetes/spec/classes/apiserver_spec.rb
@@ -336,7 +336,7 @@ describe 'kubernetes::apiserver' do
         should contain_file(service_file).with_content(/#{Regexp.escape('--service-account-api-audiences=kubernetes.default.svc')}/)
       end
     end
-    context 'with kubernetes 1.12+ with custom audiences' do
+    context 'with kubernetes 1.12+ and less then 1.13+ with custom audiences' do
       let(:pre_condition) {[
         """
             class{'kubernetes': version => '1.12.0', service_account_key_file => '/etc/kubernetes/sa.key'}
@@ -347,6 +347,19 @@ describe 'kubernetes::apiserver' do
         should contain_file(service_file).with_content(/#{Regexp.escape('--service-account-signing-key-file=/etc/kubernetes/sa.key')}/)
         should contain_file(service_file).with_content(/#{Regexp.escape('--service-account-issuer=kubernetes.default.svc')}/)
         should contain_file(service_file).with_content(/#{Regexp.escape('--service-account-api-audiences=kubernetes.default.svc,my.custom.aud.svc')}/)
+      end
+    end
+    context 'with kubernetes 1.13+ with custom audiences' do
+      let(:pre_condition) {[
+        """
+            class{'kubernetes': version => '1.13.0', service_account_key_file => '/etc/kubernetes/sa.key'}
+            class{'kubernetes::apiserver': service_account_api_audiences => ['kubernetes.default.svc', 'my.custom.aud.svc']}
+        """
+      ]}
+      it do
+        should contain_file(service_file).with_content(/#{Regexp.escape('--service-account-signing-key-file=/etc/kubernetes/sa.key')}/)
+        should contain_file(service_file).with_content(/#{Regexp.escape('--service-account-issuer=kubernetes.default.svc')}/)
+        should contain_file(service_file).with_content(/#{Regexp.escape('--api-audiences=kubernetes.default.svc,my.custom.aud.svc')}/)
       end
     end
     context 'with kubernetes before 1.12' do

--- a/puppet/modules/kubernetes/templates/kube-apiserver.service.erb
+++ b/puppet/modules/kubernetes/templates/kube-apiserver.service.erb
@@ -95,7 +95,11 @@ ExecStart=<%= scope['kubernetes::_dest_dir'] %>/apiserver \
 <% if @post_1_12 -%>
  "--service-account-signing-key-file=<%= scope['kubernetes::_service_account_key_file'] %>" \
  "--service-account-issuer=<%= @service_account_issuer %>" \
+<% if !@post_1_13 -%>
   --service-account-api-audiences=<%= @_service_account_api_audiences.join(',') %> \
+<% else -%>
+  --api-audiences=<%= @_service_account_api_audiences.join(',') %> \
+<% end -%>
 <% end -%>
 <% end -%>
 <% if @_feature_gates && @_feature_gates.length > 0 -%>

--- a/puppet/modules/kubernetes/templates/kube-apiserver.service.erb
+++ b/puppet/modules/kubernetes/templates/kube-apiserver.service.erb
@@ -95,6 +95,7 @@ ExecStart=<%= scope['kubernetes::_dest_dir'] %>/apiserver \
 <% if @post_1_12 -%>
  "--service-account-signing-key-file=<%= scope['kubernetes::_service_account_key_file'] %>" \
  "--service-account-issuer=<%= @service_account_issuer %>" \
+  --service-account-api-audiences=<%= @_service_account_api_audiences.join(',') %> \
 <% end -%>
 <% end -%>
 <% if @_feature_gates && @_feature_gates.length > 0 -%>


### PR DESCRIPTION
Adds `--service-account-api-audiences` to the api server which is required for 1.12 if other service account token flags are enabled. It defaults to the issuer url.
/assign @simonswine 

```release-note
NONE
```
